### PR TITLE
Refactor extractQuestions and set up Jest

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             <iframe id="pdfViewer"></iframe>
         </div>
     </div>
+  <script src="scripts/extract.js"></script>
 
   <script>
     let questions = [];
@@ -179,36 +180,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
     }
 }
 
-    function extractQuestions(textContent) {
-      // Nettoyer le texte extrait
-      textContent = textContent.replace(/\s\s+/g, ' ');  // Remplacer les espaces multiples par un seul espace
-      console.log("Cleaned Text Content: ", textContent);
-      
-      let questionsArray = [];
-      let questionPattern = /(?:Question \d+ :|\d+\)|Question :|\d+\.)/gi;
-      let match;
-      let lastIndex = 0;
-
-      while ((match = questionPattern.exec(textContent)) !== null) {
-        if (questionsArray.length > 0) {
-          questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex, match.index).trim();
-        }
-        questionsArray.push({ index: match.index, text: match[0] });
-        lastIndex = questionPattern.lastIndex;
-      }
-
-      if (questionsArray.length > 0) {
-        questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex).trim();
-      }
-
-      questions = questionsArray.map(q => q.text);
-      console.log("Extracted Questions : ", questions);
-
-      if (questions.length < 0) {
-        console.log("No questions found.");
-        alert("Aucune question trouvée dans le document PDF.");
-      }
-    }
 
     function startEvaluation() {
       if (synthesis && recognition && questions.length > 0) {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "dependencies": {
     "node-fetch": "^2.6.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
   "scripts": {
-    "build": "echo 'No build step required'"
+    "build": "echo 'No build step required'",
+    "test": "jest"
   },
   "author": "Jérémy VIOLETTE",
   "license": "MIT"

--- a/pdf.html
+++ b/pdf.html
@@ -47,6 +47,7 @@
             <iframe id="pdfViewer"></iframe>
         </div>
     </div>
+  <script src="scripts/extract.js"></script>
 
   <script>
     let questions = [];
@@ -159,38 +160,6 @@
       }
     }
 
-    function extractQuestions(textContent) {
-      // Nettoyer le texte extrait
-      textContent = textContent.replace(/\s\s+/g, ' ');  // Remplacer les espaces multiples par un seul espace
-      console.log("Cleaned Text Content: ", textContent);
-      
-      let questionsArray = [];
-      let questionPattern = /(?:Question \d+ :|\d+\)|Question :)/gi;
-      let match;
-      let lastIndex = 0;
-
-      while ((match = questionPattern.exec(textContent)) !== null) {
-        if (questionsArray.length > 0) {
-          questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex, match.index).trim();
-        }
-        questionsArray.push({ index: match.index, text: match[0] });
-        lastIndex = questionPattern.lastIndex;
-      }
-
-      if (questionsArray.length > 0) {
-        questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex).trim();
-      }
-
-      questions = questionsArray.map(q => q.text);
-      console.log("Extracted Questions : ", questions);
-
-      if (questions.length > 0) {
-        document.getElementById('startEval').disabled = false;
-      } else {
-        console.log("No questions found.");
-        alert("Aucune question trouvée dans le document PDF.");
-      }
-    }
 
     function startEvaluation() {
       if (synthesis && recognition && questions.length > 0) {

--- a/scripts/extract.js
+++ b/scripts/extract.js
@@ -1,0 +1,30 @@
+function extractQuestions(textContent) {
+  // Nettoyer le texte extrait
+  textContent = textContent.replace(/\s\s+/g, ' ');
+
+  let questionsArray = [];
+  // Pattern pour plusieurs formats: "Question 1 :", "2)", "3." ou "Question :"
+  let questionPattern = /(?:Question \d+ ?:|\d+\)|Question ?:|\d+\.)/gi;
+  let match;
+  let lastIndex = 0;
+
+  while ((match = questionPattern.exec(textContent)) !== null) {
+    if (questionsArray.length > 0) {
+      questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex, match.index).trim();
+    }
+    questionsArray.push({ index: match.index, text: match[0] });
+    lastIndex = questionPattern.lastIndex;
+  }
+
+  if (questionsArray.length > 0) {
+    questionsArray[questionsArray.length - 1].text += textContent.substring(lastIndex).trim();
+  }
+
+  return questionsArray.map(q => q.text);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { extractQuestions };
+} else {
+  window.extractQuestions = extractQuestions;
+}

--- a/tests/extractQuestions.test.js
+++ b/tests/extractQuestions.test.js
@@ -1,0 +1,7 @@
+const { extractQuestions } = require('../scripts/extract');
+
+test('extracts different question formats', () => {
+  const text = 'Question 1 : Quelle est la capitale de la France ? 2) Qui a decouvert l\'Amerique ? 3. Quelle est la formule de l\'eau ?';
+  const result = extractQuestions(text);
+  expect(result).toEqual(['Question 1 :', '2)', '3.']);
+});


### PR DESCRIPTION
## Summary
- move `extractQuestions` to `scripts/extract.js`
- use the new module in `index.html` and `pdf.html`
- add Jest configuration in `package.json`
- add unit test for question extraction

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d66b229c832aa4aca21b72b67b5c