### PR TITLE
Corriger les constats d’audit pour les évaluations scientifiques

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ par un verbe de Bloom peut encore être reconnue avec une confiance moyenne.
 Si plusieurs consignes sont possibles, EvalVoice affiche une boîte de
 vérification au lieu de choisir silencieusement.
 
+Les amorces comme `En déduire…`, `À partir des documents 1, 2 et 3,
+analyser…` ou `À partir du graphique : déterminer…` sont également reconnues.
+Lorsque le verbe n’est pas le premier mot, son format en gras est exigé pour
+une acceptation automatique ; sinon EvalVoice demande une confirmation.
+
 ## Utilisation
 
 - Charger un PDF local de 20 Mo maximum, ou coller un lien Google Docs.
@@ -31,6 +36,9 @@ vérification au lieu de choisir silencieusement.
 - Pour une réponse longue, la dictée continue jusqu’au clic sur
   « Arrêter la dictée ».
 - Exporter les questions et réponses en PDF.
+
+L’export utilise une police DejaVu Sans locale afin de conserver les accents,
+lettres grecques, flèches, indices et exposants des contenus scientifiques.
 
 La reconnaissance vocale fonctionne surtout dans les navigateurs Chromium.
 Quand elle n’est pas disponible, toutes les fonctions de saisie au clavier,
@@ -63,7 +71,8 @@ npm run build
 
 Le site prêt à publier est généré dans `dist/`. Les versions de PDF.js et
 jsPDF sont verrouillées dans `package-lock.json` et copiées localement lors du
-build : aucune bibliothèque JavaScript n’est chargée depuis un CDN.
+build : aucune bibliothèque JavaScript n’est chargée depuis un CDN. Les polices
+DejaVu Sans et leur licence sont également copiées dans `dist/vendor/fonts`.
 
 Commandes utiles :
 
@@ -77,6 +86,8 @@ npm run audit:prod
 `netlify.toml` configure le build, les en-têtes de sécurité et la fonction
 `/api/fetch-doc`. Les URL Netlify du déploiement sont autorisées
 automatiquement.
+
+Le déploiement de référence est <https://evalvoice.netlify.app/>.
 
 Pour ajouter d’autres domaines exacts, définir :
 

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
               <progress
                 id="progressBar"
                 class="progress-track"
+                aria-labelledby="progressText"
                 max="1"
                 value="1"
               >
@@ -224,10 +225,15 @@
       </section>
     </main>
 
-    <dialog id="questionReviewDialog" class="review-dialog">
+    <dialog
+      id="questionReviewDialog"
+      class="review-dialog"
+      aria-labelledby="reviewDialogTitle"
+      aria-describedby="reviewReason"
+    >
       <form id="reviewForm" method="dialog">
         <p class="eyebrow">Vérification nécessaire</p>
-        <h2>Confirmer la ou les questions</h2>
+        <h2 id="reviewDialogTitle">Confirmer la ou les questions</h2>
         <p id="reviewReason"></p>
         <p class="field-help">
           Corrigez le texte si besoin. Pour séparer plusieurs questions, placez

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "dejavu-fonts-ttf": "2.37.3",
         "jspdf": "4.2.1",
         "pdfjs-dist": "6.1.200"
       },
@@ -346,6 +347,12 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/dejavu-fonts-ttf": {
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/dejavu-fonts-ttf/-/dejavu-fonts-ttf-2.37.3.tgz",
+      "integrity": "sha512-f1hd7jJbeQa1VWcw+K2KrTXS50zTMaHpVC4XIKJpNcDeYR5ajMtj/iLlQDYNvLOKamUB3ARVVCf79lNwNVztSQ==",
+      "license": "SEE LICENSE IN README.md AND LICENSE"
     },
     "node_modules/dompurify": {
       "version": "3.4.12",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit:prod": "npm audit --omit=dev --audit-level=high"
   },
   "dependencies": {
+    "dejavu-fonts-ttf": "2.37.3",
     "jspdf": "4.2.1",
     "pdfjs-dist": "6.1.200"
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -21,12 +21,19 @@ await Promise.all([
   copy('styles'),
   copy('scripts/evalvoice.mjs'),
   copy('scripts/pdf_extractor.mjs'),
+  copy('scripts/pdf_export.mjs'),
   copy('scripts/question_parser.mjs'),
   copy('scripts/session_store.mjs'),
   copy('scripts/speech_chunks.mjs'),
   copy('node_modules/pdfjs-dist/build/pdf.mjs', 'vendor/pdfjs/pdf.mjs'),
   copy('node_modules/pdfjs-dist/build/pdf.worker.mjs', 'vendor/pdfjs/pdf.worker.mjs'),
-  copy('node_modules/jspdf/dist/jspdf.umd.min.js', 'vendor/jspdf/jspdf.umd.min.js')
+  copy('node_modules/jspdf/dist/jspdf.umd.min.js', 'vendor/jspdf/jspdf.umd.min.js'),
+  copy('node_modules/dejavu-fonts-ttf/ttf/DejaVuSans.ttf', 'vendor/fonts/DejaVuSans.ttf'),
+  copy(
+    'node_modules/dejavu-fonts-ttf/ttf/DejaVuSans-Bold.ttf',
+    'vendor/fonts/DejaVuSans-Bold.ttf'
+  ),
+  copy('node_modules/dejavu-fonts-ttf/LICENSE', 'vendor/fonts/DejaVu-LICENSE.txt')
 ]);
 
 console.log('EvalVoice construit dans dist/.');

--- a/scripts/evalvoice.mjs
+++ b/scripts/evalvoice.mjs
@@ -1,5 +1,6 @@
 import * as pdfjsLib from '../vendor/pdfjs/pdf.mjs';
 import { extractPdfDocument } from './pdf_extractor.mjs';
+import { createResponsesPdf, loadPdfFontFiles } from './pdf_export.mjs';
 import { detectQuestions } from './question_parser.mjs';
 import { createSessionStore } from './session_store.mjs';
 import { splitIntoSpeechChunks } from './speech_chunks.mjs';
@@ -74,6 +75,7 @@ class EvalVoiceApp {
     this.loadSequence = 0;
     this.saveTimer = null;
     this.reviewResolver = null;
+    this.pdfFontFilesPromise = null;
     this.store = createSessionStore();
     this.elements = {};
   }
@@ -792,7 +794,17 @@ class EvalVoiceApp {
     }
   }
 
-  exportResponses() {
+  async getPdfFontFiles() {
+    if (!this.pdfFontFilesPromise) {
+      this.pdfFontFilesPromise = loadPdfFontFiles().catch((error) => {
+        this.pdfFontFilesPromise = null;
+        throw error;
+      });
+    }
+    return this.pdfFontFilesPromise;
+  }
+
+  async exportResponses() {
     this.saveVisibleResponse(false);
     this.stopRecording({ announce: false, abort: true });
     const studentName = this.elements.studentName.value.trim();
@@ -806,89 +818,26 @@ class EvalVoiceApp {
       return;
     }
 
+    const exportState = {
+      evaluationTitle: this.evaluationTitle,
+      studentName,
+      questions: [...this.questions],
+      responses: [...this.responses]
+    };
+    this.elements.exportResponses.disabled = true;
+
     try {
       const { jsPDF } = window.jspdf;
-      const doc = new jsPDF({ unit: 'mm', format: 'a4' });
-      const margin = 15;
-      const pageBottom = 278;
-      const lineHeight = 5.5;
-      let y = 16;
-
-      const nextPageIfNeeded = (height = lineHeight) => {
-        if (y + height <= pageBottom) return;
-        doc.addPage();
-        y = 16;
-      };
-
-      const writeWrapped = (text, {
-        size = 11,
-        style = 'normal',
-        indent = 0,
-        spacingAfter = 3
-      } = {}) => {
-        doc.setFont('helvetica', style);
-        doc.setFontSize(size);
-        const lines = doc.splitTextToSize(String(text), 180 - indent);
-        for (const line of lines) {
-          nextPageIfNeeded(lineHeight);
-          doc.text(line, margin + indent, y);
-          y += lineHeight;
-        }
-        y += spacingAfter;
-      };
-
-      doc.setFont('helvetica', 'bold');
-      doc.setFontSize(17);
-      const titleLines = doc.splitTextToSize(this.evaluationTitle || 'Évaluation', 180);
-      for (const line of titleLines) {
-        nextPageIfNeeded(8);
-        doc.text(line, 105, y, { align: 'center' });
-        y += 8;
-      }
-      y += 2;
-      doc.setDrawColor(11, 92, 171);
-      doc.line(margin, y, 210 - margin, y);
-      y += 7;
-
-      writeWrapped(`Élève : ${studentName}`, { style: 'bold', spacingAfter: 1 });
-      writeWrapped(`Exporté le ${new Date().toLocaleString('fr-FR')}`, {
-        size: 9,
-        spacingAfter: 6
+      const fontFiles = await this.getPdfFontFiles();
+      const doc = createResponsesPdf({
+        jsPDF,
+        fontFiles,
+        ...exportState
       });
-
-      this.questions.forEach((question, index) => {
-        nextPageIfNeeded(18);
-        writeWrapped(`Question ${index + 1}`, {
-          size: 12,
-          style: 'bold',
-          spacingAfter: 1
-        });
-        writeWrapped(question, { style: 'bold', spacingAfter: 3 });
-        writeWrapped('Réponse', { size: 10, style: 'bold', spacingAfter: 1 });
-        writeWrapped(this.responses[index]?.trim() || 'Pas de réponse.', {
-          indent: 3,
-          spacingAfter: 7
-        });
-      });
-
-      const totalPages = doc.internal.getNumberOfPages();
-      const answered = this.responses.filter((response) => response?.trim()).length;
-      for (let page = 1; page <= totalPages; page += 1) {
-        doc.setPage(page);
-        doc.setFont('helvetica', 'normal');
-        doc.setFontSize(8);
-        doc.setTextColor(90);
-        doc.text(
-          `Page ${page}/${totalPages} — ${answered}/${this.questions.length} réponses`,
-          105,
-          290,
-          { align: 'center' }
-        );
-      }
 
       const filename = [
         'Evaluation',
-        cleanFilenamePart(this.evaluationTitle, 'Sujet'),
+        cleanFilenamePart(exportState.evaluationTitle, 'Sujet'),
         cleanFilenamePart(studentName, 'Eleve')
       ].join('_');
       doc.save(`${filename}.pdf`);
@@ -897,7 +846,12 @@ class EvalVoiceApp {
       this.showNotification('Les réponses ont été exportées en PDF.', 'success');
     } catch (error) {
       console.error(error);
-      this.showNotification('L’export PDF a échoué.', 'error');
+      this.showNotification(
+        error.message || 'L’export PDF a échoué.',
+        'error'
+      );
+    } finally {
+      this.elements.exportResponses.disabled = this.questions.length === 0;
     }
   }
 

--- a/scripts/pdf_export.mjs
+++ b/scripts/pdf_export.mjs
@@ -1,0 +1,153 @@
+export const PDF_FONT_FAMILY = 'DejaVuSans';
+
+const PDF_FONT_URLS = Object.freeze({
+  normal: new URL('../vendor/fonts/DejaVuSans.ttf', import.meta.url),
+  bold: new URL('../vendor/fonts/DejaVuSans-Bold.ttf', import.meta.url)
+});
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  const parts = [];
+  const chunkSize = 0x8000;
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    parts.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+    );
+  }
+
+  return globalThis.btoa(parts.join(''));
+}
+
+async function fetchFontFile(url, fetchImplementation) {
+  const response = await fetchImplementation(url);
+  if (!response.ok) {
+    throw new Error(`Police PDF indisponible (${response.status}).`);
+  }
+  return arrayBufferToBase64(await response.arrayBuffer());
+}
+
+export async function loadPdfFontFiles(
+  fetchImplementation = globalThis.fetch
+) {
+  if (typeof fetchImplementation !== 'function') {
+    throw new Error('Le chargement des polices PDF n’est pas disponible.');
+  }
+
+  const [normal, bold] = await Promise.all([
+    fetchFontFile(PDF_FONT_URLS.normal, fetchImplementation),
+    fetchFontFile(PDF_FONT_URLS.bold, fetchImplementation)
+  ]);
+  return { normal, bold };
+}
+
+export function registerPdfFonts(doc, fontFiles) {
+  if (!fontFiles?.normal || !fontFiles?.bold) {
+    throw new Error('Les polices Unicode nécessaires à l’export sont absentes.');
+  }
+
+  doc.addFileToVFS('DejaVuSans.ttf', fontFiles.normal);
+  doc.addFont('DejaVuSans.ttf', PDF_FONT_FAMILY, 'normal');
+  doc.addFileToVFS('DejaVuSans-Bold.ttf', fontFiles.bold);
+  doc.addFont('DejaVuSans-Bold.ttf', PDF_FONT_FAMILY, 'bold');
+}
+
+export function createResponsesPdf({
+  jsPDF,
+  fontFiles,
+  evaluationTitle = 'Évaluation',
+  studentName,
+  questions,
+  responses,
+  exportedAt = new Date()
+}) {
+  if (typeof jsPDF !== 'function') {
+    throw new Error('Le module d’export PDF n’est pas disponible.');
+  }
+
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  registerPdfFonts(doc, fontFiles);
+
+  const margin = 15;
+  const pageBottom = 278;
+  const lineHeight = 5.5;
+  let y = 16;
+
+  const nextPageIfNeeded = (height = lineHeight) => {
+    if (y + height <= pageBottom) return;
+    doc.addPage();
+    y = 16;
+  };
+
+  const writeWrapped = (text, {
+    size = 11,
+    style = 'normal',
+    indent = 0,
+    spacingAfter = 3
+  } = {}) => {
+    doc.setFont(PDF_FONT_FAMILY, style);
+    doc.setFontSize(size);
+    const lines = doc.splitTextToSize(String(text), 180 - indent);
+    for (const line of lines) {
+      nextPageIfNeeded(lineHeight);
+      doc.text(line, margin + indent, y);
+      y += lineHeight;
+    }
+    y += spacingAfter;
+  };
+
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  doc.setFontSize(17);
+  const titleLines = doc.splitTextToSize(evaluationTitle || 'Évaluation', 180);
+  for (const line of titleLines) {
+    nextPageIfNeeded(8);
+    doc.text(line, 105, y, { align: 'center' });
+    y += 8;
+  }
+  y += 2;
+  doc.setDrawColor(11, 92, 171);
+  doc.line(margin, y, 210 - margin, y);
+  y += 7;
+
+  writeWrapped(`Élève : ${studentName}`, { style: 'bold', spacingAfter: 1 });
+  writeWrapped(`Exporté le ${exportedAt.toLocaleString('fr-FR')}`, {
+    size: 9,
+    spacingAfter: 6
+  });
+
+  questions.forEach((question, index) => {
+    nextPageIfNeeded(18);
+    writeWrapped(`Question ${index + 1}`, {
+      size: 12,
+      style: 'bold',
+      spacingAfter: 1
+    });
+    writeWrapped(question, { style: 'bold', spacingAfter: 3 });
+    writeWrapped('Réponse', { size: 10, style: 'bold', spacingAfter: 1 });
+    writeWrapped(responses[index]?.trim() || 'Pas de réponse.', {
+      indent: 3,
+      spacingAfter: 7
+    });
+  });
+
+  const totalPages = doc.internal.getNumberOfPages();
+  const answered = responses.filter((response) => response?.trim()).length;
+  for (let page = 1; page <= totalPages; page += 1) {
+    doc.setPage(page);
+    doc.setFont(PDF_FONT_FAMILY, 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(90);
+    doc.text(
+      `Page ${page}/${totalPages} — ${answered}/${questions.length} réponses`,
+      105,
+      290,
+      { align: 'center' }
+    );
+  }
+
+  return doc;
+}
+
+export const pdfExportInternals = Object.freeze({
+  arrayBufferToBase64
+});

--- a/scripts/pdf_extractor.mjs
+++ b/scripts/pdf_extractor.mjs
@@ -113,9 +113,12 @@ function pageItemsToLines(textContent, pageNumber, fontObjects = {}) {
     .map((row) => {
       const orderedItems = [...row.items].sort((a, b) => a.x - b.x);
       const firstTextItem = orderedItems.find((item) => item.text);
+      const boldText = joinItems(orderedItems.filter((item) => item.isBold));
       return {
         text: joinItems(orderedItems),
         isBoldStart: Boolean(firstTextItem?.isBold),
+        boldWords:
+          boldText.match(/[\p{L}À-ÿŒœ][\p{L}À-ÿŒœ'’-]*/gu) ?? [],
         pageNumber
       };
     })

--- a/scripts/question_parser.mjs
+++ b/scripts/question_parser.mjs
@@ -28,7 +28,7 @@ const NUMBERED_PATTERN =
   /^\s*(?:(question|q)\s*)?(\d{1,3})\s*(?:[)\].:–—-])\s*(.*)$/iu;
 
 const SECTION_BOUNDARY_PATTERN =
-  /^\s*(?:bar[eè]me|corrig[eé]|correction|crit[eè]res?(?:\s+d['’][eé]valuation)?|grille\s+d['’][eé]valuation|annexes?|documents?\s+(?:ressources?|annexes?)|comp[eé]tences?\s+[eé]valu[eé]es?)\s*:?\s*$/iu;
+  /^\s*(?:bar[eè]me|corrig[eé]|correction|crit[eè]res?(?:\s+d['’][eé]valuation)?|grille\s+d['’][eé]valuation|annexes?|documents?\s+(?:ressources?|annexes?)|comp[eé]tences?\s+[eé]valu[eé]es?)\s*(?::\s*.*)?$/iu;
 
 const NEGATIVE_CONTEXT_PATTERN =
   /\b(?:bar[eè]me|notation|points?|crit[eè]res?|corrig[eé]|correction)\b/iu;
@@ -56,26 +56,64 @@ function stripEmphasis(value) {
     .replace(/(?:\*\*|__|<\/strong>)/iu, '');
 }
 
+function wordsOf(value) {
+  return String(value ?? '').match(/[\p{L}À-ÿŒœ][\p{L}À-ÿŒœ'’-]*/gu) ?? [];
+}
+
+function emphasizedWords(value) {
+  const words = [];
+  const pattern = /(?:\*\*|__|<strong>)(.*?)(?:\*\*|__|<\/strong>)/giu;
+  for (const match of String(value ?? '').matchAll(pattern)) {
+    words.push(...wordsOf(match[1]));
+  }
+  return words;
+}
+
 function normalizeLines(source) {
   if (Array.isArray(source)) {
     return source.flatMap((line, sourceIndex) => {
       const text = typeof line === 'string' ? line : line?.text;
-      return String(text ?? '').split(/\r?\n/).map((part) => ({
-        text: cleanLine(part),
-        isBoldStart: Boolean(
-          typeof line === 'object' && (line.isBoldStart || line.isBold)
-        ) || /^\s*(?:\*\*|__|<strong>)/iu.test(part),
-        pageNumber: typeof line === 'object' ? line.pageNumber : undefined,
-        sourceIndex
-      }));
+      return String(text ?? '').split(/\r?\n/).map((part) => {
+        const markedWords = emphasizedWords(part);
+        const suppliedWords =
+          typeof line === 'object'
+            ? Array.isArray(line.boldWords)
+              ? line.boldWords
+              : wordsOf(line.boldText)
+            : [];
+        const hasSuppliedMetadata = Boolean(
+          typeof line === 'object' &&
+          (
+            Object.hasOwn(line, 'boldWords') ||
+            Object.hasOwn(line, 'boldText')
+          )
+        );
+
+        return {
+          text: cleanLine(part),
+          isBoldStart: Boolean(
+            typeof line === 'object' && (line.isBoldStart || line.isBold)
+          ) || /^\s*(?:\*\*|__|<strong>)/iu.test(part),
+          boldWords: [...suppliedWords, ...markedWords],
+          hasBoldWordMetadata:
+            hasSuppliedMetadata || markedWords.length > 0,
+          pageNumber: typeof line === 'object' ? line.pageNumber : undefined,
+          sourceIndex
+        };
+      });
     });
   }
 
-  return String(source ?? '').split(/\r?\n/).map((text, sourceIndex) => ({
-    text: cleanLine(text),
-    isBoldStart: /^\s*(?:\*\*|__|<strong>)/iu.test(text),
-    sourceIndex
-  }));
+  return String(source ?? '').split(/\r?\n/).map((text, sourceIndex) => {
+    const markedWords = emphasizedWords(text);
+    return {
+      text: cleanLine(text),
+      isBoldStart: /^\s*(?:\*\*|__|<strong>)/iu.test(text),
+      boldWords: markedWords,
+      hasBoldWordMetadata: markedWords.length > 0,
+      sourceIndex
+    };
+  });
 }
 
 export function getLeadingBloomVerb(value) {
@@ -94,10 +132,6 @@ const LEADING_CONNECTORS = new Set([
   'en', 'puis', 'ensuite', 'enfin', 'alors', 'donc', 'ainsi', 'apres'
 ]);
 
-function wordsOf(value) {
-  return value.match(/[\p{L}À-ÿŒœ][\p{L}À-ÿŒœ'’-]*/gu) ?? [];
-}
-
 function firstBloomAfterConnectors(words) {
   for (const word of words) {
     const normalized = fold(word.replace(/[’']/g, ''));
@@ -109,23 +143,44 @@ function firstBloomAfterConnectors(words) {
 
 /**
  * Détecte un verbe de Bloom en tête de proposition : en début de ligne (en
- * sautant d'éventuels connecteurs), ou juste après la première virgule. Couvre
- * « En déduire… » et « À partir du graphique, déterminer… » sans découper une
- * consigne à chacun de ses verbes internes.
+ * sautant d'éventuels connecteurs), ou juste après une ponctuation d'amorce.
+ * Le type de position est conservé afin que l'appelant exige un signal de gras
+ * pour les verbes non initiaux.
  */
-export function getBloomVerbNearStart(value) {
+export function getBloomMatchNearStart(value) {
   const base = stripEmphasis(value).replace(NUMBERED_PATTERN, '$3');
 
-  const leading = firstBloomAfterConnectors(wordsOf(base));
-  if (leading) return leading;
+  const direct = getLeadingBloomVerb(base);
+  if (direct) return { verb: direct, position: 'initial' };
 
-  const commaIndex = base.indexOf(',');
-  if (commaIndex >= 0) {
-    const clause = firstBloomAfterConnectors(wordsOf(base.slice(commaIndex + 1)));
-    if (clause) return clause;
+  const afterConnectors = firstBloomAfterConnectors(wordsOf(base));
+  if (afterConnectors) {
+    return { verb: afterConnectors, position: 'prefixed' };
+  }
+
+  for (const punctuation of base.matchAll(/[,;:]/gu)) {
+    const clause = firstBloomAfterConnectors(
+      wordsOf(base.slice(punctuation.index + punctuation[0].length))
+    );
+    if (clause) return { verb: clause, position: 'prefixed' };
   }
 
   return null;
+}
+
+export function getBloomVerbNearStart(value) {
+  return getBloomMatchNearStart(value)?.verb ?? null;
+}
+
+function lineHasBoldVerb(line, verb, position) {
+  if (position === 'initial' && line.isBoldStart) return true;
+  const normalizedVerb = fold(verb.replace(/[’']/g, ''));
+  const explicitlyBold = line.boldWords.some(
+    (word) => fold(word.replace(/[’']/g, '')) === normalizedVerb
+  );
+  if (explicitlyBold) return true;
+  if (line.hasBoldWordMetadata) return false;
+  return line.isBoldStart;
 }
 
 function isQuestionLike(value) {
@@ -303,13 +358,14 @@ function extractBloom(lines) {
   const candidates = [];
 
   lines.forEach((line, lineIndex) => {
-    const verb = getBloomVerbNearStart(line.text);
-    if (!verb) return;
+    const match = getBloomMatchNearStart(line.text);
+    if (!match) return;
 
     const candidate = {
       lineIndex,
-      verb,
-      isBoldStart: line.isBoldStart
+      verb: match.verb,
+      position: match.position,
+      isBoldStart: lineHasBoldVerb(line, match.verb, match.position)
     };
     candidate.score = scoreBloomCandidate(candidate, lines);
     candidates.push(candidate);
@@ -325,6 +381,7 @@ function extractBloom(lines) {
   const hasReliableBoldSignal = best.isBoldStart && (!runnerUp || best.score > runnerUp.score);
   const isUniquePlainCandidate =
     credible.length === 1 &&
+    best.position === 'initial' &&
     previewFrom(lines, best.lineIndex, 4).length >= 35;
 
   if (!hasReliableBoldSignal && !isUniquePlainCandidate) {
@@ -341,7 +398,9 @@ function extractBloom(lines) {
       confidence: 'low',
       requiresReview: true,
       suggestion: suggestions.join('\n\n---\n\n'),
-      reason: 'Plusieurs consignes commençant par un verbe de Bloom ont été trouvées.'
+      reason: credible.length > 1
+        ? 'Plusieurs consignes commençant par un verbe de Bloom ont été trouvées.'
+        : 'Un verbe de Bloom non initial a été trouvé, mais son format en gras doit être confirmé.'
     };
   }
 

--- a/scripts/speech_chunks.mjs
+++ b/scripts/speech_chunks.mjs
@@ -47,6 +47,38 @@ function splitSentenceByWords(sentence, limit) {
   return chunks;
 }
 
+function splitAtSentenceBoundaries(text) {
+  const sentences = [];
+  let start = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (!/[.!?;:…]/u.test(text[index])) continue;
+
+    let punctuationEnd = index;
+    while (
+      punctuationEnd + 1 < text.length &&
+      /[.!?;:…]/u.test(text[punctuationEnd + 1])
+    ) {
+      punctuationEnd += 1;
+    }
+
+    const nextCharacter = text[punctuationEnd + 1];
+    if (nextCharacter !== undefined && nextCharacter !== ' ') {
+      index = punctuationEnd;
+      continue;
+    }
+
+    const sentence = text.slice(start, punctuationEnd + 1).trim();
+    if (sentence) sentences.push(sentence);
+    start = punctuationEnd + 1;
+    index = punctuationEnd;
+  }
+
+  const remainder = text.slice(start).trim();
+  if (remainder) sentences.push(remainder);
+  return sentences;
+}
+
 /**
  * Découpe un texte en énoncés de synthèse d'au plus `limit` caractères.
  *
@@ -55,7 +87,10 @@ function splitSentenceByWords(sentence, limit) {
  * @returns {string[]}
  */
 export function splitIntoSpeechChunks(text, limit = SPEECH_CHUNK_LIMIT) {
-  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : SPEECH_CHUNK_LIMIT;
+  const safeLimit =
+    Number.isFinite(limit) && limit >= 1
+      ? Math.floor(limit)
+      : SPEECH_CHUNK_LIMIT;
   const normalized = String(text ?? '')
     .replace(/\s+/gu, ' ')
     .trim();
@@ -64,8 +99,10 @@ export function splitIntoSpeechChunks(text, limit = SPEECH_CHUNK_LIMIT) {
   if (normalized.length <= safeLimit) return [normalized];
 
   // On conserve la ponctuation finale de chaque phrase pour garder une
-  // prosodie correcte.
-  const sentences = normalized.match(/[^.!?;:…]+(?:[.!?;:…]+|$)/gu) ?? [normalized];
+  // prosodie correcte. Une ponctuation n'est une frontière que si elle est
+  // suivie d'une espace ou de la fin du texte : les décimales (9.81), ratios
+  // (1:2), URL et autres notations scientifiques restent donc intactes.
+  const sentences = splitAtSentenceBoundaries(normalized);
   const chunks = [];
   let current = '';
 

--- a/tests/pdf_export.test.mjs
+++ b/tests/pdf_export.test.mjs
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { jsPDF } from 'jspdf';
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+
+import {
+  createResponsesPdf,
+  loadPdfFontFiles,
+  PDF_FONT_FAMILY
+} from '../scripts/pdf_export.mjs';
+
+const normalFont = await readFile(
+  new URL(
+    '../node_modules/dejavu-fonts-ttf/ttf/DejaVuSans.ttf',
+    import.meta.url
+  )
+);
+const boldFont = await readFile(
+  new URL(
+    '../node_modules/dejavu-fonts-ttf/ttf/DejaVuSans-Bold.ttf',
+    import.meta.url
+  )
+);
+const fontFiles = {
+  normal: normalFont.toString('base64'),
+  bold: boldFont.toString('base64')
+};
+
+test('charge les deux polices depuis les ressources locales', async () => {
+  const requested = [];
+  const loaded = await loadPdfFontFiles(async (url) => {
+    requested.push(url.pathname.slice(url.pathname.lastIndexOf('/vendor/')));
+    const bytes = url.pathname.endsWith('DejaVuSans-Bold.ttf')
+      ? boldFont
+      : normalFont;
+    return new Response(bytes, {
+      status: 200,
+      headers: { 'Content-Type': 'font/ttf' }
+    });
+  });
+
+  assert.deepEqual(requested, [
+    '/vendor/fonts/DejaVuSans.ttf',
+    '/vendor/fonts/DejaVuSans-Bold.ttf'
+  ]);
+  assert.deepEqual(loaded, fontFiles);
+});
+
+test('exporte sans corruption les symboles scientifiques Unicode', async () => {
+  const scientificQuestion =
+    'Déterminer Δt, λ et Ω puis comparer avec μ, →, ≤ et ≥.';
+  const scientificResponse =
+    'H₂O se déplace à 9,81 m·s⁻² dans le modèle étudié.';
+  const document = createResponsesPdf({
+    jsPDF,
+    fontFiles,
+    evaluationTitle: 'Évaluation de physique-chimie',
+    studentName: 'Jérémie Dupont — 3e',
+    questions: [scientificQuestion],
+    responses: [scientificResponse],
+    exportedAt: new Date('2026-07-23T12:00:00Z')
+  });
+
+  assert.equal(document.getFont().fontName, PDF_FONT_FAMILY);
+
+  const loadingTask = pdfjsLib.getDocument({
+    data: new Uint8Array(document.output('arraybuffer')),
+    isEvalSupported: false,
+    useSystemFonts: true
+  });
+  const pdf = await loadingTask.promise;
+
+  try {
+    const page = await pdf.getPage(1);
+    const content = await page.getTextContent();
+    const text = content.items.map((item) => item.str).join(' ');
+
+    assert.match(text, /Jérémie Dupont — 3e/u);
+    assert.match(text, /Δt, λ et Ω/u);
+    assert.match(text, /μ, →, ≤ et ≥/u);
+    assert.match(text, /H₂O/u);
+    assert.match(text, /m·s⁻²/u);
+  } finally {
+    await loadingTask.destroy();
+  }
+});
+
+test('pagine une réponse longue avec la police Unicode enregistrée', () => {
+  const document = createResponsesPdf({
+    jsPDF,
+    fontFiles,
+    studentName: 'Élève test',
+    questions: ['Analyser les résultats.'],
+    responses: ['Réponse développée avec Δ et H₂O. '.repeat(500)],
+    exportedAt: new Date('2026-07-23T12:00:00Z')
+  });
+
+  assert.ok(document.internal.getNumberOfPages() > 1);
+});

--- a/tests/pdf_extractor.test.mjs
+++ b/tests/pdf_extractor.test.mjs
@@ -73,6 +73,46 @@ test('conserve le signal de gras au début de la ligne', () => {
   assert.equal(lines.length, 1);
   assert.equal(lines[0].text, 'Analyser les résultats.');
   assert.equal(lines[0].isBoldStart, true);
+  assert.deepEqual(lines[0].boldWords, ['Analyser']);
+});
+
+test('conserve le mot en gras après une amorce non grasse', () => {
+  const lines = pageItemsToLines({
+    styles: {
+      Bold: { fontFamily: 'Liberation Sans Bold' },
+      Regular: { fontFamily: 'Liberation Sans' }
+    },
+    items: [
+      {
+        str: 'À partir du graphique,',
+        transform: [10, 0, 0, 10, 10, 700],
+        width: 105,
+        height: 10,
+        fontName: 'Regular'
+      },
+      {
+        str: 'déterminer',
+        transform: [10, 0, 0, 10, 120, 700],
+        width: 48,
+        height: 10,
+        fontName: 'Bold'
+      },
+      {
+        str: 'la constante de temps.',
+        transform: [10, 0, 0, 10, 173, 700],
+        width: 92,
+        height: 10,
+        fontName: 'Regular'
+      }
+    ]
+  }, 1);
+
+  assert.equal(
+    lines[0].text,
+    'À partir du graphique, déterminer la constante de temps.'
+  );
+  assert.equal(lines[0].isBoldStart, false);
+  assert.deepEqual(lines[0].boldWords, ['déterminer']);
 });
 
 test('reconnaît de bout en bout le verbe en gras dans un vrai PDF', async () => {
@@ -100,4 +140,36 @@ test('reconnaît de bout en bout le verbe en gras dans un vrai PDF', async () =>
   assert.equal(result.questions.length, 1);
   assert.match(result.questions[0], /^Analyser les documents/u);
   assert.doesNotMatch(result.questions[0], /Critères/u);
+});
+
+test('reconnaît dans un vrai PDF un verbe en gras après plusieurs virgules', async () => {
+  const document = new jsPDF();
+  const prefix = 'À partir des documents 1, 2 et 3,';
+  const verb = 'analyser';
+  const suffix = 'la solution proposée et justifier la réponse.';
+  const y = 38;
+
+  document.setFont('helvetica', 'normal');
+  document.text('Évaluation niveau 3', 15, 18);
+  document.text(prefix, 15, y);
+  let x = 15 + document.getTextWidth(prefix) + 1.5;
+  document.setFont('helvetica', 'bold');
+  document.text(verb, x, y);
+  x += document.getTextWidth(verb) + 1.5;
+  document.setFont('helvetica', 'normal');
+  document.text(suffix, x, y);
+  document.setFont('helvetica', 'bold');
+  document.text('Barème : 10 points', 15, 65);
+
+  const extracted = await extractPdfDocument(
+    new Uint8Array(document.output('arraybuffer')),
+    pdfjsLib
+  );
+  const result = detectQuestions(extracted.lines);
+
+  assert.equal(result.strategy, 'bold-bloom-verb');
+  assert.equal(result.bloomVerb, verb);
+  assert.equal(result.questions.length, 1);
+  assert.match(result.questions[0], /^À partir des documents 1, 2 et 3, analyser/u);
+  assert.doesNotMatch(result.questions[0], /Barème/u);
 });

--- a/tests/question_parser.test.mjs
+++ b/tests/question_parser.test.mjs
@@ -84,6 +84,19 @@ test('ne confond pas une liste de barème avec des questions', () => {
   assert.equal(result.questions.length, 0);
 });
 
+test('arrête la dernière question avant un barème renseigné sur la même ligne', () => {
+  const result = detectQuestions([
+    { text: '1) Identifier la grandeur représentée sur le graphique.' },
+    { text: '2) Calculer sa valeur puis justifier la méthode choisie.' },
+    { text: 'Barème : 5 points répartis entre le calcul et la justification.' },
+    { text: 'Présentation : 1 point' }
+  ]);
+
+  assert.equal(result.requiresReview, false);
+  assert.equal(result.questions.length, 2);
+  assert.doesNotMatch(result.questions[1], /Barème/u);
+});
+
 test('demande une validation quand plusieurs verbes de Bloom en gras sont ambigus', () => {
   const result = detectQuestions([
     { text: 'Analyser les résultats de la première expérience.', isBoldStart: true },
@@ -128,6 +141,62 @@ test('reconnaît un verbe de Bloom après un connecteur ou une virgule', () => {
     'déterminer'
   );
   assert.equal(getBloomVerbNearStart('Puis calculer la valeur moyenne.'), 'calculer');
+});
+
+test('reconnaît les amorces à plusieurs virgules et avec deux-points', () => {
+  assert.equal(
+    getBloomVerbNearStart(
+      'À partir des documents 1, 2 et 3, analyser la solution proposée.'
+    ),
+    'analyser'
+  );
+  assert.equal(
+    getBloomVerbNearStart(
+      'À partir du graphique : déterminer la constante de temps.'
+    ),
+    'déterminer'
+  );
+});
+
+test('auto-accepte une amorce non initiale seulement si le verbe est en gras', () => {
+  const boldResult = detectQuestions([
+    {
+      text: 'À partir des documents 1, 2 et 3, analyser la solution proposée et justifier la réponse.',
+      boldWords: ['analyser']
+    }
+  ]);
+  const plainResult = detectQuestions([
+    {
+      text: 'À partir des documents 1, 2 et 3, analyser la solution proposée et justifier la réponse.'
+    }
+  ]);
+
+  assert.equal(boldResult.strategy, 'bold-bloom-verb');
+  assert.equal(boldResult.requiresReview, false);
+  assert.equal(plainResult.strategy, 'ambiguous-bloom');
+  assert.equal(plainResult.requiresReview, true);
+});
+
+test('reconnaît un verbe non initial entouré de marqueurs de gras', () => {
+  const result = detectQuestions(
+    'Sujet\nÀ partir du graphique : **déterminer** la constante de temps du système.'
+  );
+
+  assert.equal(result.strategy, 'bold-bloom-verb');
+  assert.equal(result.requiresReview, false);
+  assert.equal(result.bloomVerb, 'déterminer');
+});
+
+test('envoie une phrase descriptive avec un verbe après virgule en validation', () => {
+  const result = detectQuestions([
+    {
+      text: 'Dans cette fiche, observer signifie regarder attentivement sans intervenir.'
+    }
+  ]);
+
+  assert.equal(result.strategy, 'ambiguous-bloom');
+  assert.equal(result.requiresReview, true);
+  assert.equal(result.questions.length, 0);
 });
 
 test('n’assimile pas un verbe interne de consigne à une amorce', () => {

--- a/tests/speech_chunks.test.mjs
+++ b/tests/speech_chunks.test.mjs
@@ -45,3 +45,26 @@ test('coupe un mot unique plus long que la limite', () => {
     assert.ok(chunk.length <= SPEECH_CHUNK_LIMIT);
   }
 });
+
+test('préserve les décimales et ratios dans une tâche complexe longue', () => {
+  const paragraph = [
+    'Analyser les mesures et expliciter chaque étape du raisonnement.',
+    'Utiliser g = 9.81 m/s² et le rapport 1:2 pour effectuer le calcul final.',
+    'Conclure en comparant la valeur obtenue au modèle proposé.'
+  ].join(' ');
+  const text = `${paragraph} `.repeat(3).trim();
+  const normalized = text.replace(/\s+/gu, ' ').trim();
+  const chunks = splitIntoSpeechChunks(text, 90);
+
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks.join(' '), normalized);
+  assert.ok(chunks.some((chunk) => chunk.includes('9.81')));
+  assert.ok(chunks.some((chunk) => chunk.includes('1:2')));
+});
+
+test('remplace une limite fractionnaire invalide par la limite sûre', () => {
+  const chunks = splitIntoSpeechChunks('x'.repeat(250), 0.5);
+
+  assert.equal(chunks.length, 2);
+  assert.ok(chunks.every((chunk) => chunk.length <= SPEECH_CHUNK_LIMIT));
+});

--- a/tests/static_contract.test.mjs
+++ b/tests/static_contract.test.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 
 const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 const app = await readFile(new URL('../scripts/evalvoice.mjs', import.meta.url), 'utf8');
+const build = await readFile(new URL('../scripts/build.mjs', import.meta.url), 'utf8');
 
 test('la page ne charge aucun script tiers et ne contient aucun gestionnaire inline', () => {
   assert.doesNotMatch(html, /https?:\/\/(?:cdnjs|unpkg|jsdelivr)/iu);
@@ -25,4 +26,23 @@ test('la réponse est une zone multiligne et le sélecteur PDF reste accessible'
   assert.match(html, /<textarea[\s\S]*?id="responseInput"/u);
   assert.match(html, /<input id="fileInput" type="file"/u);
   assert.doesNotMatch(html, /id="fileInput"[^>]+display\s*:\s*none/iu);
+});
+
+test('la boîte de validation et la progression ont un nom accessible', () => {
+  assert.match(
+    html,
+    /<dialog[\s\S]*?aria-labelledby="reviewDialogTitle"/u
+  );
+  assert.match(html, /<h2 id="reviewDialogTitle">/u);
+  assert.match(
+    html,
+    /<progress[\s\S]*?aria-labelledby="progressText"/u
+  );
+});
+
+test('le build embarque les deux polices Unicode et leur licence', () => {
+  assert.match(build, /DejaVuSans\.ttf/u);
+  assert.match(build, /DejaVuSans-Bold\.ttf/u);
+  assert.match(build, /DejaVu-LICENSE\.txt/u);
+  assert.match(build, /scripts\/pdf_export\.mjs/u);
 });


### PR DESCRIPTION
## Résumé

Cette PR résout les constats restants du nouvel audit d’EvalVoice :

- préservation des nombres décimaux et des ratios pendant le découpage de la synthèse vocale ;
- suppression du risque de boucle infinie avec une limite de découpage fractionnaire ;
- reconnaissance des tâches complexes de niveau 3 introduites par plusieurs virgules ou par un deux-points ;
- règle de sûreté pour les verbes de Bloom non initiaux : acceptation automatique uniquement lorsque le verbe est réellement en gras, sinon validation manuelle ;
- rejet des faux positifs descriptifs tels que « observer signifie… » ;
- reconnaissance des fins de section contenant du texte, notamment `Barème : 5 points répartis…` ;
- export PDF avec DejaVu Sans pour préserver le grec, les flèches, les symboles mathématiques, les indices et les exposants ;
- amélioration des libellés ARIA de la progression et de la fenêtre de validation.

## Validation

- `npm ci`
- `npm run check` — 50/50 tests réussis
- `npm run build`
- `npm run audit:prod` — 0 vulnérabilité
- ESLint, html-validate, contrôle syntaxique et `git diff --check`
- test réel de PDF : `Δ`, `λ`, `Ω`, `μ`, `→`, `≤`, `≥`, `H₂O`, `m·s⁻²` préservés
- rendu visuel contrôlé sur un document multipage

Aucun fichier de `main` n’a été modifié directement.