### PR TITLE
Extraire les consignes successives des tâches complexes

### DIFF
--- a/scripts/question_parser.mjs
+++ b/scripts/question_parser.mjs
@@ -33,6 +33,12 @@ const SECTION_BOUNDARY_PATTERN =
 const NEGATIVE_CONTEXT_PATTERN =
   /\b(?:bar[eè]me|notation|points?|crit[eè]res?|corrig[eé]|correction)\b/iu;
 
+// Les grilles d'évaluation placent souvent un code très court (COM, RCO/,
+// APP...) juste après la formulation d'une compétence. Ce signal permet de ne
+// pas confondre « Rédiger un texte... » avec une consigne destinée à l'élève.
+const COMPETENCY_CODE_PATTERN =
+  /^[A-ZÀ-ÖØ-Þ]{2,6}(?:\s*[/+.-]\s*[A-ZÀ-ÖØ-Þ0-9]{0,6})?$/u;
+
 const INTERROGATIVE_PATTERN =
   /^(?:a\s+partir|comment|dans\s+quelle\s+mesure|de\s+quelle|explique|indique|pourquoi|qu['’]est-ce|quel(?:le)?s?\b|qui\b|relevez|selon\b)/iu;
 
@@ -354,12 +360,78 @@ function scoreBloomCandidate(candidate, lines) {
   return score;
 }
 
+function nextNonEmptyLine(lines, startIndex) {
+  return lines.slice(startIndex).find((line) => line.text);
+}
+
+function isCompetencyGridCandidate(lines, lineIndex) {
+  const nextLine = nextNonEmptyLine(lines, lineIndex + 1);
+  return Boolean(nextLine && COMPETENCY_CODE_PATTERN.test(nextLine.text));
+}
+
+function hasSectionBoundaryBetween(lines, startIndex, endIndex) {
+  return lines
+    .slice(startIndex + 1, endIndex)
+    .some((line) => SECTION_BOUNDARY_PATTERN.test(line.text));
+}
+
+function extractBoldBloomSequence(candidates, lines) {
+  const boldCandidates = candidates.filter((candidate) => candidate.isBoldStart);
+  if (boldCandidates.length < 2) return null;
+
+  // Une limite de section sépare deux groupes de consignes. On retient le
+  // groupe cohérent le mieux noté, puis on borne chaque question à la suivante.
+  const runs = [];
+  for (const candidate of boldCandidates) {
+    const currentRun = runs.at(-1);
+    const previous = currentRun?.at(-1);
+    if (
+      previous &&
+      !hasSectionBoundaryBetween(lines, previous.lineIndex, candidate.lineIndex)
+    ) {
+      currentRun.push(candidate);
+    } else {
+      runs.push([candidate]);
+    }
+  }
+
+  const bestRun = runs
+    .filter((run) => run.length >= 2)
+    .sort((left, right) => {
+      const scoreDifference =
+        right.reduce((total, candidate) => total + candidate.score, 0) -
+        left.reduce((total, candidate) => total + candidate.score, 0);
+      return scoreDifference || right.length - left.length;
+    })[0];
+  if (!bestRun) return null;
+
+  const questions = bestRun.map((candidate, index) => {
+    const nextCandidate = bestRun[index + 1];
+    const hardEnd = nextCandidate?.lineIndex ?? lines.length;
+    const endIndex = findBoundaryIndex(lines, candidate.lineIndex + 1, hardEnd);
+    return joinQuestionLines(lines, candidate.lineIndex, endIndex);
+  }).filter((question) => question.length >= 10);
+
+  if (questions.length !== bestRun.length) return null;
+
+  return {
+    questions,
+    strategy: 'bold-bloom-sequence',
+    confidence: 'high',
+    requiresReview: false,
+    bloomVerbs: bestRun.map((candidate) => candidate.verb),
+    reason:
+      `Une séquence de ${questions.length} consignes commençant par des verbes de Bloom en gras a été reconnue.`
+  };
+}
+
 function extractBloom(lines) {
   const candidates = [];
 
   lines.forEach((line, lineIndex) => {
     const match = getBloomMatchNearStart(line.text);
     if (!match) return;
+    if (isCompetencyGridCandidate(lines, lineIndex)) return;
 
     const candidate = {
       lineIndex,
@@ -373,11 +445,15 @@ function extractBloom(lines) {
 
   const credible = candidates
     .filter((candidate) => candidate.score >= 2)
-    .sort((a, b) => b.score - a.score);
+    .sort((a, b) => a.lineIndex - b.lineIndex);
   if (credible.length === 0) return null;
 
-  const best = credible[0];
-  const runnerUp = credible[1];
+  const sequence = extractBoldBloomSequence(credible, lines);
+  if (sequence) return sequence;
+
+  const ranked = [...credible].sort((a, b) => b.score - a.score);
+  const best = ranked[0];
+  const runnerUp = ranked[1];
   const hasReliableBoldSignal = best.isBoldStart && (!runnerUp || best.score > runnerUp.score);
   const isUniquePlainCandidate =
     credible.length === 1 &&
@@ -385,10 +461,19 @@ function extractBloom(lines) {
     previewFrom(lines, best.lineIndex, 4).length >= 35;
 
   if (!hasReliableBoldSignal && !isUniquePlainCandidate) {
-    const suggestions = credible
+    const suggestions = ranked
       .slice(0, 4)
-      .map((candidate) => {
-        const end = findBoundaryIndex(lines, candidate.lineIndex + 1);
+      .map((candidate, index, selected) => {
+        const nextCandidateIndex = selected
+          .filter((other) => other.lineIndex > candidate.lineIndex)
+          .map((other) => other.lineIndex)
+          .sort((a, b) => a - b)[0];
+        const hardEnd = nextCandidateIndex ?? lines.length;
+        const end = findBoundaryIndex(
+          lines,
+          candidate.lineIndex + 1,
+          hardEnd
+        );
         return joinQuestionLines(lines, candidate.lineIndex, end);
       });
 

--- a/tests/question_parser.test.mjs
+++ b/tests/question_parser.test.mjs
@@ -97,15 +97,79 @@ test('arrête la dernière question avant un barème renseigné sur la même lig
   assert.doesNotMatch(result.questions[1], /Barème/u);
 });
 
-test('demande une validation quand plusieurs verbes de Bloom en gras sont ambigus', () => {
+test('traite plusieurs consignes de Bloom en gras comme des questions successives', () => {
   const result = detectQuestions([
     { text: 'Analyser les résultats de la première expérience.', isBoldStart: true },
     { text: 'Comparer les résultats avec ceux de la seconde expérience.', isBoldStart: true }
   ]);
 
+  assert.equal(result.requiresReview, false);
+  assert.equal(result.strategy, 'bold-bloom-sequence');
+  assert.deepEqual(result.questions, [
+    'Analyser les résultats de la première expérience.',
+    'Comparer les résultats avec ceux de la seconde expérience.'
+  ]);
+});
+
+test('extrait le sujet Superman sans popup, doublon ni compétence parasite', () => {
+  const result = detectQuestions([
+    {
+      text: 'Rédiger un texte structuré à l’aide de phrases simples.',
+      isBoldStart: true
+    },
+    { text: 'COM' },
+    {
+      text: 'Rendre un travail propre et soigné.',
+      isBoldStart: true
+    },
+    { text: 'RCO/' },
+    { text: 'Document 1 : Superman est né sur la planète Krypton.' },
+    {
+      text: 'Document 2 : Les fibres musculaires de Superman sont prévues pour fonctionner sur Krypton.'
+    },
+    {
+      text: 'Calculer la masse d’un objet que Superman peut soulever sur Krypton, s’il exerce la',
+      isBoldStart: true,
+      boldWords: ['Calculer']
+    },
+    {
+      text: 'même force que celle nécessaire pour soulever une voiture de 1 tonne sur Terre, en'
+    },
+    {
+      text: 'utilisant les informations des documents et tes connaissances.'
+    },
+    {
+      text: 'Conclure sur l’origine réelle des super-pouvoirs de Superman.',
+      isBoldStart: true,
+      boldWords: ['Conclure']
+    }
+  ]);
+
+  assert.equal(result.requiresReview, false);
+  assert.equal(result.strategy, 'bold-bloom-sequence');
+  assert.deepEqual(result.bloomVerbs, ['Calculer', 'Conclure']);
+  assert.deepEqual(result.questions, [
+    'Calculer la masse d’un objet que Superman peut soulever sur Krypton, s’il exerce la\n' +
+      'même force que celle nécessaire pour soulever une voiture de 1 tonne sur Terre, en\n' +
+      'utilisant les informations des documents et tes connaissances.',
+    'Conclure sur l’origine réelle des super-pouvoirs de Superman.'
+  ]);
+  assert.doesNotMatch(result.questions.join('\n'), /Rédiger|Rendre|COM|RCO/u);
+});
+
+test('borne aussi les suggestions ambiguës pour éviter les blocs imbriqués', () => {
+  const result = detectQuestions([
+    { text: 'Calculer la valeur de la vitesse moyenne.' },
+    { text: 'Conclure sur la validité de l’hypothèse.' }
+  ]);
+
   assert.equal(result.requiresReview, true);
   assert.equal(result.strategy, 'ambiguous-bloom');
-  assert.match(result.suggestion, /---/u);
+  assert.equal(
+    result.suggestion,
+    'Calculer la valeur de la vitesse moyenne.\n\n---\n\n' +
+      'Conclure sur la validité de l’hypothèse.'
+  );
 });
 
 test('tolère un PDF qui ne permet pas d’identifier le gras si la tâche est unique', () => {


### PR DESCRIPTION
## Problème constaté

Une évaluation de niveau 3 contenant plusieurs consignes en gras, par exemple `Calculer…` puis `Conclure…`, était considérée comme ambiguë. EvalVoice affichait alors à l’élève une fenêtre de validation contenant des blocs imbriqués et répétés.

## Correction

- plusieurs consignes fiables commençant par des verbes de Bloom en gras deviennent des questions successives, toutes obligatoires ;
- chaque question est bornée par la consigne suivante, ce qui supprime les duplications et chevauchements ;
- les formulations de la grille de compétences suivies d’un code court (`COM`, `RCO/`, `APP`…) sont exclues des candidats ;
- les suggestions des cas réellement ambigus sont elles aussi bornées pour ne plus produire de blocs imbriqués ;
- un test reproduit précisément l’évaluation Superman avec `Calculer…` et `Conclure…`.

## Résultat attendu pour le sujet Superman

1. `Calculer la masse d’un objet que Superman peut soulever…`
2. `Conclure sur l’origine réelle des super-pouvoirs de Superman.`

Aucune popup n’est affichée pour ce cas et les compétences `Rédiger… / COM` et `Rendre… / RCO/` sont ignorées.

## Validation

- `npm run check` — 52/52 tests réussis
- `npm run build`
- `npm run audit:prod` — 0 vulnérabilité
- `git diff --check`
