### PR TITLE
Utiliser directement les consignes successives détectées

### DIFF
--- a/scripts/question_parser.mjs
+++ b/scripts/question_parser.mjs
@@ -375,14 +375,20 @@ function hasSectionBoundaryBetween(lines, startIndex, endIndex) {
     .some((line) => SECTION_BOUNDARY_PATTERN.test(line.text));
 }
 
-function extractBoldBloomSequence(candidates, lines) {
-  const boldCandidates = candidates.filter((candidate) => candidate.isBoldStart);
-  if (boldCandidates.length < 2) return null;
+function extractBloomSequence(candidates, lines) {
+  // Le signal de gras est parfois perdu lors de l'export PDF. Plusieurs
+  // consignes qui commencent directement par un verbe restent néanmoins une
+  // séquence fiable. En revanche, une amorce non initiale sans gras conserve
+  // le filet de validation afin d'éviter les faux positifs descriptifs.
+  const sequenceCandidates = candidates.filter(
+    (candidate) => candidate.isBoldStart || candidate.position === 'initial'
+  );
+  if (sequenceCandidates.length < 2) return null;
 
   // Une limite de section sépare deux groupes de consignes. On retient le
   // groupe cohérent le mieux noté, puis on borne chaque question à la suivante.
   const runs = [];
-  for (const candidate of boldCandidates) {
+  for (const candidate of sequenceCandidates) {
     const currentRun = runs.at(-1);
     const previous = currentRun?.at(-1);
     if (
@@ -414,14 +420,17 @@ function extractBoldBloomSequence(candidates, lines) {
 
   if (questions.length !== bestRun.length) return null;
 
+  const allBold = bestRun.every((candidate) => candidate.isBoldStart);
   return {
     questions,
-    strategy: 'bold-bloom-sequence',
-    confidence: 'high',
+    strategy: allBold ? 'bold-bloom-sequence' : 'bloom-sequence',
+    confidence: allBold ? 'high' : 'medium',
     requiresReview: false,
     bloomVerbs: bestRun.map((candidate) => candidate.verb),
     reason:
-      `Une séquence de ${questions.length} consignes commençant par des verbes de Bloom en gras a été reconnue.`
+      allBold
+        ? `Une séquence de ${questions.length} consignes commençant par des verbes de Bloom en gras a été reconnue.`
+        : `Une séquence cohérente de ${questions.length} consignes commençant par des verbes de Bloom a été reconnue.`
   };
 }
 
@@ -448,7 +457,7 @@ function extractBloom(lines) {
     .sort((a, b) => a.lineIndex - b.lineIndex);
   if (credible.length === 0) return null;
 
-  const sequence = extractBoldBloomSequence(credible, lines);
+  const sequence = extractBloomSequence(credible, lines);
   if (sequence) return sequence;
 
   const ranked = [...credible].sort((a, b) => b.score - a.score);

--- a/tests/question_parser.test.mjs
+++ b/tests/question_parser.test.mjs
@@ -157,19 +157,34 @@ test('extrait le sujet Superman sans popup, doublon ni compétence parasite', ()
   assert.doesNotMatch(result.questions.join('\n'), /Rédiger|Rendre|COM|RCO/u);
 });
 
-test('borne aussi les suggestions ambiguës pour éviter les blocs imbriqués', () => {
+test('utilise automatiquement plusieurs consignes successives même si le gras est perdu', () => {
   const result = detectQuestions([
     { text: 'Calculer la valeur de la vitesse moyenne.' },
     { text: 'Conclure sur la validité de l’hypothèse.' }
   ]);
 
+  assert.equal(result.requiresReview, false);
+  assert.equal(result.strategy, 'bloom-sequence');
+  assert.equal(result.confidence, 'medium');
+  assert.deepEqual(result.questions, [
+    'Calculer la valeur de la vitesse moyenne.',
+    'Conclure sur la validité de l’hypothèse.'
+  ]);
+});
+
+test('conserve la validation pour une amorce non initiale sans gras', () => {
+  const result = detectQuestions([
+    {
+      text: 'À partir du graphique, calculer la valeur de la vitesse moyenne.'
+    },
+    {
+      text: 'Dans cette fiche, observer signifie regarder attentivement.'
+    }
+  ]);
+
   assert.equal(result.requiresReview, true);
   assert.equal(result.strategy, 'ambiguous-bloom');
-  assert.equal(
-    result.suggestion,
-    'Calculer la valeur de la vitesse moyenne.\n\n---\n\n' +
-      'Conclure sur la validité de l’hypothèse.'
-  );
+  assert.equal(result.questions.length, 0);
 });
 
 test('tolère un PDF qui ne permet pas d’identifier le gras si la tâche est unique', () => {


### PR DESCRIPTION
## Problème

Sur certains PDF, EvalVoice trouve correctement plusieurs consignes successives (`Calculer…`, puis `Conclure…`) mais l’export PDF ne restitue pas assez fiablement leur mise en gras. Le parseur conservait alors la popup de validation manuelle, inadaptée aux élèves.

## Correction

- plusieurs consignes cohérentes commençant directement par un verbe de Bloom sont désormais utilisées automatiquement ;
- le gras augmente toujours la confiance, mais son absence dans les métadonnées PDF ne bloque plus une séquence claire ;
- les amorces non initiales sans gras et les formulations descriptives ambiguës restent soumises au filet de validation ;
- le cas Superman est couvert avec et sans détection du gras.

## Effet pour les élèves

Lorsque `Calculer…` et `Conclure…` sont trouvées, EvalVoice ouvre directement l’évaluation avec les deux questions. Aucune popup de confirmation n’est affichée.

## Validation

- `npm run check` — 53/53 tests réussis
- `npm run build`
- `npm run audit:prod` — 0 vulnérabilité
- `git diff --check`
