### PR TITLE
Diffuser les PDF Google Docs jusqu’à 20 Mo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ une acceptation automatique ; sinon EvalVoice demande une confirmation.
 
 ## Utilisation
 
-- Charger un PDF local de 20 Mo maximum, ou coller un lien Google Docs.
+- Charger un PDF local de 20 Mo maximum, ou coller un lien Google Docs dont
+  l’export PDF ne dépasse pas 20 Mo.
 - Vérifier la question reconnue si EvalVoice le demande.
 - Utiliser « Lire la question », puis saisir ou dicter la réponse.
 - Pour une réponse longue, la dictée continue jusqu’au clic sur

--- a/docs/AUDIT_TECHNIQUE_2026-07-23.md
+++ b/docs/AUDIT_TECHNIQUE_2026-07-23.md
@@ -34,7 +34,7 @@ La refonte corrige ces points sans ajouter de stockage serveur des réponses.
 | Haute | Une tâche complexe non numérotée devenait le document entier. | Détection d’un verbe de Bloom en début de ligne ; le gras augmente fortement la confiance. |
 | Haute | Des entrées de barème comme `1) 2 points` pouvaient être prises pour des questions. | Score par séquence, contenu interrogatif, verbes de Bloom, contexte négatif et arrêt avant les sections de barème. |
 | Haute | Le proxy acceptait des origines par suffixe, échouait en mode ouvert et utilisait un rate limiter en mémoire. | Origines exactes, refus par défaut, seule donnée acceptée : un identifiant Google Docs, rate limit natif Netlify. |
-| Haute | La taille distante de 10 Mo ne tenait pas compte des limites de réponse d’une fonction Netlify. | Limite de 4 Mo contrôlée avant et pendant le flux. |
+| Haute | La taille distante de 10 Mo ne tenait pas compte des limites de réponse d’une fonction Netlify. | Réponse diffusée en streaming, avec une limite de 20 Mo contrôlée avant et pendant le flux. |
 | Haute | L’ancien proxy permissif restait déployable. | Suppression de `fetch-doc_old.js` et remplacement par une seule fonction moderne. |
 | Moyenne | La reconnaissance vocale s’arrêtait au premier résultat final et écrasait la réponse. | Mode continu, accumulation des segments, zone multiligne et arrêt explicite. |
 | Moyenne | L’application exigeait le microphone au démarrage et s’arrêtait si l’API vocale manquait. | Permission demandée uniquement après action ; fallback clavier complet. |

--- a/functions/fetch-doc.mjs
+++ b/functions/fetch-doc.mjs
@@ -1,7 +1,8 @@
-const MAX_FILE_SIZE = 4 * 1024 * 1024;
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 25_000;
 const MAX_REQUEST_BODY_SIZE = 2_048;
 const DOCUMENT_ID_PATTERN = /^[A-Za-z0-9_-]{20,128}$/u;
+const MAX_FILE_SIZE_LABEL = '20 Mo';
 
 class PublicError extends Error {
   constructor(message, status = 400) {
@@ -88,14 +89,82 @@ function jsonResponse(payload, status, headers = {}) {
   });
 }
 
-function mergeChunks(chunks, totalLength) {
-  const combined = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    combined.set(chunk, offset);
-    offset += chunk.byteLength;
+function declaredContentLength(response) {
+  const value = response.headers.get('content-length');
+  if (!value || !/^\d+$/u.test(value)) return null;
+  const size = Number(value);
+  return Number.isSafeInteger(size) ? size : null;
+}
+
+/**
+ * Transmet le corps Google Docs sans le mettre entièrement en mémoire.
+ * Le minuteur reste actif jusqu'à la fin de la lecture et le flux est coupé
+ * dès que la limite de sécurité est franchie.
+ */
+function createGuardedPdfStream(
+  upstreamBody,
+  {
+    maxFileSize,
+    abortController,
+    timeout
   }
-  return combined;
+) {
+  const reader = upstreamBody.getReader();
+  let totalLength = 0;
+  let finished = false;
+
+  const cleanup = () => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(timeout);
+  };
+
+  return new ReadableStream({
+    async pull(streamController) {
+      try {
+        const { value, done } = await reader.read();
+        if (done) {
+          cleanup();
+          if (totalLength === 0) {
+            streamController.error(
+              new PublicError('Google Docs a renvoyé un document vide.', 502)
+            );
+            return;
+          }
+          streamController.close();
+          return;
+        }
+        if (!value) return;
+
+        totalLength += value.byteLength;
+        if (totalLength > maxFileSize) {
+          cleanup();
+          abortController.abort();
+          await reader.cancel();
+          streamController.error(
+            new PublicError(
+              `Le PDF dépasse la taille maximale de ${MAX_FILE_SIZE_LABEL}.`,
+              413
+            )
+          );
+          return;
+        }
+        streamController.enqueue(value);
+      } catch (error) {
+        cleanup();
+        streamController.error(
+          error.name === 'AbortError'
+            ? new PublicError('Le téléchargement a dépassé 25 secondes.', 504)
+            : error
+        );
+      }
+    },
+    async cancel(reason) {
+      cleanup();
+      abortController.abort();
+      await reader.cancel(reason);
+    }
+  });
 }
 
 export async function downloadGooglePdf(
@@ -108,6 +177,7 @@ export async function downloadGooglePdf(
 ) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let streamCreated = false;
 
   try {
     const response = await fetchImplementation(googlePdfUrl(documentId), {
@@ -137,42 +207,32 @@ export async function downloadGooglePdf(
       );
     }
 
-    const declaredSize = Number(response.headers.get('content-length'));
-    if (Number.isFinite(declaredSize) && declaredSize > maxFileSize) {
-      throw new PublicError('Le PDF dépasse la taille maximale de 4 Mo.', 413);
+    const declaredSize = declaredContentLength(response);
+    if (declaredSize !== null && declaredSize > maxFileSize) {
+      throw new PublicError(
+        `Le PDF dépasse la taille maximale de ${MAX_FILE_SIZE_LABEL}.`,
+        413
+      );
     }
     if (!response.body) {
       throw new PublicError('Google Docs a renvoyé un document vide.', 502);
     }
 
-    const reader = response.body.getReader();
-    const chunks = [];
-    let totalLength = 0;
-
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-
-      totalLength += value.byteLength;
-      if (totalLength > maxFileSize) {
-        await reader.cancel();
-        throw new PublicError('Le PDF dépasse la taille maximale de 4 Mo.', 413);
-      }
-      chunks.push(value);
-    }
-
-    if (totalLength === 0) {
-      throw new PublicError('Google Docs a renvoyé un document vide.', 502);
-    }
-    return mergeChunks(chunks, totalLength);
+    const body = createGuardedPdfStream(response.body, {
+      maxFileSize,
+      abortController: controller,
+      timeout
+    });
+    streamCreated = true;
+    return { body, declaredSize };
   } catch (error) {
     if (error.name === 'AbortError') {
       throw new PublicError('Le téléchargement a dépassé 25 secondes.', 504);
     }
     throw error;
   } finally {
-    clearTimeout(timeout);
+    // Une fois le flux rendu à l'appelant, son cycle de vie gère le minuteur.
+    if (!streamCreated) clearTimeout(timeout);
   }
 }
 
@@ -210,7 +270,7 @@ export default async function handler(request) {
     }
 
     const pdf = await downloadGooglePdf(body.documentId);
-    return new Response(pdf, {
+    return new Response(pdf.body, {
       status: 200,
       headers: {
         ...headers,

--- a/index.html
+++ b/index.html
@@ -72,7 +72,8 @@
                 placeholder="https://docs.google.com/document/d/…"
               >
               <p class="field-help">
-                Le document doit être accessible avec le lien pour pouvoir être exporté en PDF.
+                Le document doit être accessible avec le lien et son export PDF ne doit pas
+                dépasser 20 Mo.
               </p>
               <button id="loadDocumentButton" class="button" type="button">
                 Charger le document

--- a/scripts/evalvoice.mjs
+++ b/scripts/evalvoice.mjs
@@ -9,7 +9,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc =
   new URL('../vendor/pdfjs/pdf.worker.mjs', import.meta.url).href;
 
 const MAX_LOCAL_PDF_SIZE = 20 * 1024 * 1024;
-const MAX_REMOTE_PDF_SIZE = 4 * 1024 * 1024;
+const MAX_REMOTE_PDF_SIZE = 20 * 1024 * 1024;
 const RECOGNITION_RESTART_LIMIT = 20;
 
 function joinTranscript(...parts) {
@@ -247,7 +247,7 @@ class EvalVoiceApp {
       if (!response.ok) throw new Error(await this.readErrorResponse(response));
       const blob = await response.blob();
       if (blob.size > MAX_REMOTE_PDF_SIZE) {
-        throw new Error('Le PDF distant dépasse la taille maximale de 4 Mo.');
+        throw new Error('Le PDF distant dépasse la taille maximale de 20 Mo.');
       }
       if (loadId !== this.loadSequence) return;
 

--- a/tests/fetch_doc.test.mjs
+++ b/tests/fetch_doc.test.mjs
@@ -11,6 +11,10 @@ import handler, {
 
 const documentId = '1AbCdEfGhIjKlMnOpQrStUvWxYz_123456';
 
+async function readBytes(stream) {
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
 test('valide strictement un identifiant Google Docs', () => {
   assert.equal(validateDocumentId(documentId), true);
   assert.equal(validateDocumentId('../etc/passwd'), false);
@@ -64,7 +68,11 @@ test('télécharge un PDF en respectant le type MIME et la taille', async () => 
   });
 
   assert.equal(requestedUrl, googlePdfUrl(documentId));
-  assert.deepEqual([...pdf], [0x25, 0x50, 0x44, 0x46]);
+  assert.equal(pdf.declaredSize, 4);
+  assert.deepEqual(
+    [...await readBytes(pdf.body)],
+    [0x25, 0x50, 0x44, 0x46]
+  );
 });
 
 test('refuse un téléchargement qui annonce une taille excessive', async () => {
@@ -73,11 +81,75 @@ test('refuse un téléchargement qui annonce une taille excessive', async () => 
       new Response(new Uint8Array([1]), {
         headers: {
           'Content-Type': 'application/pdf',
-          'Content-Length': '5000000'
+          'Content-Length': String(21 * 1024 * 1024)
         }
       })
     ),
     /taille maximale/u
+  );
+});
+
+test('accepte et diffuse un PDF Google Docs de 4,6 Mo', async () => {
+  const bytes = new Uint8Array(4_600_000);
+  bytes.set([0x25, 0x50, 0x44, 0x46]);
+  const pdf = await downloadGooglePdf(documentId, async () =>
+    new Response(bytes, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Length': String(bytes.byteLength)
+      }
+    })
+  );
+
+  const received = await readBytes(pdf.body);
+  assert.equal(pdf.declaredSize, 4_600_000);
+  assert.equal(received.byteLength, 4_600_000);
+  assert.deepEqual([...received.slice(0, 4)], [0x25, 0x50, 0x44, 0x46]);
+});
+
+test('interrompt un flux sans taille déclarée quand il dépasse la limite', async () => {
+  const pdf = await downloadGooglePdf(
+    documentId,
+    async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(6));
+            controller.enqueue(new Uint8Array(6));
+            controller.close();
+          }
+        }),
+        { headers: { 'Content-Type': 'application/pdf' } }
+      ),
+    { maxFileSize: 10 }
+  );
+
+  await assert.rejects(readBytes(pdf.body), /taille maximale/u);
+});
+
+test('le handler renvoie le PDF sous forme de flux lisible', async (context) => {
+  const originalFetch = globalThis.fetch;
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async () =>
+    new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46]), {
+      headers: { 'Content-Type': 'application/pdf' }
+    });
+
+  const response = await handler(
+    new Request('https://evalvoice.test/api/fetch-doc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ documentId })
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/pdf');
+  assert.deepEqual(
+    [...new Uint8Array(await response.arrayBuffer())],
+    [0x25, 0x50, 0x44, 0x46]
   );
 });
 

--- a/tests/static_contract.test.mjs
+++ b/tests/static_contract.test.mjs
@@ -46,3 +46,9 @@ test('le build embarque les deux polices Unicode et leur licence', () => {
   assert.match(build, /DejaVu-LICENSE\.txt/u);
   assert.match(build, /scripts\/pdf_export\.mjs/u);
 });
+
+test('les PDF locaux et Google Docs partagent la limite de 20 Mo', () => {
+  assert.match(app, /MAX_LOCAL_PDF_SIZE\s*=\s*20\s*\*\s*1024\s*\*\s*1024/u);
+  assert.match(app, /MAX_REMOTE_PDF_SIZE\s*=\s*20\s*\*\s*1024\s*\*\s*1024/u);
+  assert.match(html, /export PDF ne doit pas\s+dépasser 20 Mo/u);
+});


### PR DESCRIPTION
## Problème

Les fichiers locaux étaient acceptés jusqu’à 20 Mo, mais les documents chargés par lien Google Docs étaient bloqués à 4 Mo. Cette limite venait de la taille maximale des réponses binaires mises en mémoire par une fonction Netlify.

## Correction

- le PDF Google Docs est désormais transmis progressivement par une réponse en streaming au lieu d’être entièrement reconstitué dans la fonction ;
- les fichiers Google Docs et locaux partagent une limite cohérente de 20 Mo ;
- la taille déclarée est contrôlée avant le transfert ;
- les flux sans taille déclarée sont comptés pendant la transmission et interrompus au-delà de 20 Mo ;
- le délai maximal de 25 secondes reste actif jusqu’à la fin réelle du flux ;
- l’interface et la documentation indiquent la limite Google Docs de 20 Mo.

## Validation

- test explicite d’un PDF de 4,6 Mo transmis intégralement ;
- test d’interruption d’un flux sans `Content-Length` dépassant la limite ;
- test du handler et de sa réponse PDF diffusée ;
- `npm run check` — 57/57 tests réussis ;
- `npm run build` ;
- `npm run audit:prod` — 0 vulnérabilité ;
- `git diff --check`.

Cette approche utilise la capacité Netlify de réponse diffusée, annoncée jusqu’à 20 Mo, au lieu de simplement relever la constante d’une réponse classique.