### PR TITLE
Centre le pied de page et sécurise PDF.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     >
     <meta name="theme-color" content="#0b5cab">
     <title>EvalVoice — Évaluations vocales</title>
-    <link rel="stylesheet" href="styles/styles.css">
+    <link rel="stylesheet" href="styles/styles.css?v=2.0.1">
     <script defer src="vendor/jspdf/jspdf.umd.min.js"></script>
     <script type="module" src="scripts/evalvoice.mjs"></script>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dejavu-fonts-ttf": "2.37.3",
         "jspdf": "4.2.1",
-        "pdfjs-dist": "6.1.200"
+        "pdfjs-dist": "6.2.108"
       },
       "engines": {
         "node": ">=24"
@@ -435,9 +435,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.1.200",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
-      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "version": "6.2.108",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "dejavu-fonts-ttf": "2.37.3",
     "jspdf": "4.2.1",
-    "pdfjs-dist": "6.1.200"
+    "pdfjs-dist": "6.2.108"
   },
   "engines": {
     "node": ">=24"

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -638,12 +638,15 @@ code {
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  width: min(96rem, 100%);
+  width: fit-content;
+  max-width: min(42rem, calc(100% - 2rem));
   margin: 1rem auto 0;
-  border-top: 0.0625rem solid var(--border);
-  padding: 1rem 1.25rem;
+  border: 0.0625rem solid rgb(174 185 200 / 65%);
+  border-radius: 1rem;
+  padding: 0.75rem 1.25rem;
   color: var(--muted);
   background: var(--surface);
+  box-shadow: 0 0.5rem 1.5rem rgb(23 32 51 / 10%);
   font-size: 0.85rem;
   text-align: center;
 }
@@ -748,8 +751,7 @@ code {
   .app-footer {
     flex-direction: column;
     gap: 0.4rem;
-    margin-top: 0;
-    padding-block: 1.25rem;
+    padding-block: 1rem;
   }
 
   .control-row .button,

--- a/tests/static_contract.test.mjs
+++ b/tests/static_contract.test.mjs
@@ -55,6 +55,8 @@ test('le pied de page identifie le développeur, la licence et le code source', 
   assert.match(html, /EvalVoice\/blob\/main\/LICENSE/u);
   assert.match(html, />Licence MIT<\/a>/u);
   assert.match(html, />Code source<\/a>/u);
+});
+
 test('les PDF locaux et Google Docs partagent la limite de 20 Mo', () => {
   assert.match(app, /MAX_LOCAL_PDF_SIZE\s*=\s*20\s*\*\s*1024\s*\*\s*1024/u);
   assert.match(app, /MAX_REMOTE_PDF_SIZE\s*=\s*20\s*\*\s*1024\s*\*\s*1024/u);


### PR DESCRIPTION
## Ce qui change

- transforme le pied de page en petit encart blanc centré ;
- ajoute une bordure arrondie et une ombre légère, dans l’esprit de TrouveTaVoie ;
- conserve une disposition adaptée aux petits écrans ;
- ajoute une version à l’URL de la feuille de style afin d’éviter l’ancien CSS conservé en cache ;
- met `pdfjs-dist` à jour de `6.1.200` vers `6.2.108` ;
- actualise le fichier de verrouillage avec l’intégrité publiée par npm.

## Pourquoi

La première version du pied de page utilisait toute la largeur et le navigateur pouvait conserver l’ancienne feuille de style pendant une heure. Par ailleurs, `pdfjs-dist 6.1.200` est concerné par une vulnérabilité élevée permettant l’exécution de JavaScript lors de l’ouverture d’un PDF malveillant. La version `6.2.108` corrige cette vulnérabilité.

## Validation attendue

La CI exécute les tests, la vérification du code, le build et l’audit des dépendances de production.